### PR TITLE
Permission fix

### DIFF
--- a/blacklist/views.py
+++ b/blacklist/views.py
@@ -1,4 +1,5 @@
 from allianceauth.eveonline.models import EveCharacter
+from allianceauth.authentication.decorators import permissions_required
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib import messages
@@ -104,7 +105,9 @@ def blacklist(request):
 
 
 @login_required
-@permission_required('blacklist.add_new_eve_note_comments')
+@permissions_required(
+    ("blacklist.add_new_eve_note_comments", "blacklist.view_eve_notes")
+)
 def get_evenote_comments(request, evenote_id=None):
     view_restricted = request.user.has_perm('view_eve_note_restricted_comments')
     comments = EveNote.objects.prefetch_related('comment').get(id=evenote_id).comment.all()


### PR DESCRIPTION
Fix permissions for `get_evenote_comments` view.

The `blacklist.view_eve_notes` enables the button to view the comments in the pilot log view, but the Python view function did not take this permission into account. So clicking on the button did result in a broken UI

![image](https://github.com/user-attachments/assets/6f21562d-67dd-4acb-925b-a62fc7ba574c)

This MR fixes this.